### PR TITLE
Decompile in multiple processes to speed up decompilation step

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -21,6 +21,9 @@ Uncompyle6Path = /Library/Frameworks/Python.framework/Versions/3.7/bin/uncompyle
 # For windows: where uncompyle6
 # Uncompyle6Path = C:\Users\<user name>\AppData\Local\Programs\Python\Python37\Scripts\uncompyle6.exe
 
+# Number of worker processes
+workers = 10
+
 [Mod]
 # add your mod name here
 Name = MyFirstMod

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -8,6 +8,7 @@ game_content_dir = config['Directory']['Sims4GameContentDir']
 mods_dir = config['Directory']['Sims4ModDir']
 uncompyle6 = config['Dependency']['Uncompyle6Path']
 mod_name = config['Mod']['Name']
+num_decompilers = config.getint('Dependency','workers')
 
 game_content_python = game_content_dir + config['Directory']['GameContentPython']
 game_content_gameplay = game_content_dir + '/Data/Simulation/Gameplay'


### PR DESCRIPTION
By using multiprocess Pool the decompilation step can be made much faster.
If the CPU and IO are not choking it speeds up the decompilation to slightly above `total_time / workers`

On my machine (CPU and IO were choking) the decompilation time was decreased from 2.5hrs (same code, single worker set in config) to 30minutes (10 workers maximum, most of the time only 3-4 uncompyle6 processes were running the same time).